### PR TITLE
feat: fpcmoc add support for 0x10A5:0x9924 fingerprint sensor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+libfprint (1:1.94.9-1deepin3) unstable; urgency=medium
+
+  * fpcmoc: Add support for 0x10A5:0x9924
+    - Add USB ID 0x10A5:0x9924 to autosuspend.hwdb
+    - Add device entry to fpcmoc driver id_table and probe
+    - Add fallback handling for non-standard identity format in verify
+
+ -- lichenggang <lichenggang@uniontech.com>  Tue, 30 Jun 2026 10:58:20 +0800
+
 libfprint (1:1.94.9-1deepin2) unstable; urgency=medium
 
   * Add riscv64 timeout multiplier support in debian/rules

--- a/debian/patches/0001-fpcmoc-Add-support-for-0x10A5-0x9924.patch
+++ b/debian/patches/0001-fpcmoc-Add-support-for-0x10A5-0x9924.patch
@@ -1,0 +1,73 @@
+Index: libfprint/data/autosuspend.hwdb
+===================================================================
+--- libfprint.orig/data/autosuspend.hwdb
++++ libfprint/data/autosuspend.hwdb
+@@ -190,6 +190,7 @@ usb:v10A5pD205*
+ usb:v10A5p9524*
+ usb:v10A5p9544*
+ usb:v10A5pC844*
++usb:v10A5p9924*
+  ID_AUTOSUSPEND=1
+  ID_PERSIST=0
+ 
+Index: libfprint/libfprint/drivers/fpcmoc/fpc.c
+===================================================================
+--- libfprint.orig/libfprint/drivers/fpcmoc/fpc.c
++++ libfprint/libfprint/drivers/fpcmoc/fpc.c
+@@ -71,6 +71,7 @@ static const FpIdEntry id_table[] = {
+   { .vid = 0x10A5,  .pid = 0x9524,  },
+   { .vid = 0x10A5,  .pid = 0x9544,  },
+   { .vid = 0x10A5,  .pid = 0xC844,  },
++  { .vid = 0x10A5,  .pid = 0x9924,  },
+   /* terminating entry */
+   { .vid = 0,  .pid = 0,  .driver_data = 0 },
+ };
+@@ -1209,11 +1210,17 @@ fpc_verify_cb (FpiDeviceFpcMoc *self,
+     }
+ 
+   presp = (FPC_IDENTIFY *) data;
++  fp_dbg ("IDENTIFY response: status=%d, subfactor=0x%x, identity_type=0x%x, "
++           "identity_size=%u, identity_offset=%u",
++           presp->status, presp->subfactor, presp->identity_type,
++           presp->identity_size, presp->identity_offset);
++
+   current_action = fpi_device_get_current_action (device);
+ 
+   g_assert (current_action == FPI_DEVICE_ACTION_VERIFY ||
+             current_action == FPI_DEVICE_ACTION_IDENTIFY);
+ 
++  /* Check for a match using standard identity format */
+   if ((presp->status == 0) && (presp->subfactor == FPC_SUBTYPE_RESERVED) &&
+       (presp->identity_type == FPC_IDENTITY_TYPE_RESERVED) &&
+       (presp->identity_size <= SECURITY_MAX_SID_SIZE))
+@@ -1266,6 +1273,22 @@ fpc_verify_cb (FpiDeviceFpcMoc *self,
+         }
+     }
+ 
++  /* Some sensors (e.g. FPC L:2407) return status=0 with zero identity fields.
++   * In verify mode, trust the sensor's match result directly. */
++  else if (presp->status == 0 && current_action == FPI_DEVICE_ACTION_VERIFY)
++    {
++      FpPrint *print = NULL;
++      fp_dbg ("Sensor reported match with non-standard identity format, "
++               "trusting sensor match result");
++      fpi_device_get_verify_data (device, &print);
++      if (print)
++        {
++          fpi_device_verify_report (device, FPI_MATCH_SUCCESS, print, error);
++          fpi_ssm_mark_completed (self->task_ssm);
++          return;
++        }
++    }
++
+   if (!found)
+     {
+       if (current_action == FPI_DEVICE_ACTION_VERIFY)
+@@ -1644,6 +1667,7 @@ fpc_dev_probe (FpDevice *device)
+     case 0x9524:
+     case 0x9544:
+     case 0xC844:
++    case 0x9924:
+       self->max_enroll_stage = MAX_ENROLL_SAMPLES;
+       break;
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -2,3 +2,4 @@
 add-uru4000-suspend-resume.patch
 0001-Add-error-handling-for-fpi_device_suspend_complete.patch
 0001-skip-tests-fpi-device.patch
+0001-fpcmoc-Add-support-for-0x10A5-0x9924.patch


### PR DESCRIPTION
Add the new FPC fingerprint device (0x10A5:0x9924) to the fpcmoc driver and autosuspend hwdb through debian quilt patch system.

Also add fallback handling for non-standard identity format used by some sensors (e.g. FPC L:2407) during verify, where the sensor reports a match with zero identity fields.

Log: Added fpcmoc support for 0x10A5:0x9924 fingerprint sensor

Influence:
1. Verify 0x10A5:0x9924 device is recognized by fprintd
2. Test enroll/verify/identify on 0x10A5:0x9924 device
3. Verify autosuspend works correctly for the new device
4. Test verify with FPC L:2407 sensor non-standard identity format
5. Ensure no regression on existing supported devices

feat: 为 fpcmoc 添加 0x10A5:0x9924 指纹传感器支持

通过 debian quilt 补丁系统，为 fpcmoc 驱动和 autosuspend hwdb 添加新的 FPC 指纹设备 (0x10A5:0x9924) 支持。

同时添加对某些传感器（如 FPC L:2407）在验证期间使用的非标准
身份格式的回退处理，这类传感器在匹配成功时返回零身份字段。

Log: 为 fpcmoc 添加 0x10A5:0x9924 指纹传感器支持

Influence:
1. 验证 fprintd 能识别 0x10A5:0x9924 设备
2. 测试新设备的 enroll/verify/identify 功能
3. 验证新设备的 autosuspend 正常工作
4. 测试 FPC L:2407 传感器非标准身份格式的验证
5. 确保现有支持的设备没有回归

repo: libfprint #feat/fpcmoc-add-0x10A5-0x9924